### PR TITLE
Add correct license and author values to package.json

### DIFF
--- a/.changeset/curly-drinks-behave.md
+++ b/.changeset/curly-drinks-behave.md
@@ -1,0 +1,5 @@
+---
+"string-replace-transform-stream": patch
+---
+
+Add correct license and author values to package.json

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "string",
     "string-replace-transform-stream"
   ],
-  "author": "",
-  "license": "ISC",
+  "author": "samuel.laycock@cloudmix.dev",
+  "license": "MIT",
   "devDependencies": {
     "@biomejs/biome": "~1.4.1",
     "@changesets/cli": "~2.27.1",


### PR DESCRIPTION
This PR adds the correct `license` and `author` values to the `package.json` file